### PR TITLE
Cleanup code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This is a fork of [aalekhpatel07/rust-s3-async](https://github.com/aalekhpatel07
 
 It's used in our internal and upcoming projects, and is not intended to be used by anyone else. It's not published on crates.io, and the API is not stable.
 
-### Intro
+## Introduction
 
 Rust library for working with Amazon S3 or arbitrary S3 compatible APIs, fully compatible with `async/await`. Uses `tokio` under the hood.
 
-#### Quick Start
+## Quick Start
 
 Read and run examples from the `examples` folder, make sure you have valid credentials for the variant you're running.
 
@@ -33,91 +33,44 @@ cargo run --example r2
 cargo run --example google-cloud
 ```
 
-#### Features
+## Features
 
-There are a lot of various features that enable a wide variety of use cases, refer to `s3/Cargo.toml` for an exhaustive list. Below is a table of various useful features as well as a short description for each.
+There are a lot of various features that enable a wide variety of use cases, refer to `s3/Cargo.toml` for an exhaustive list. 
 
 + `default` - `tokio` runtime and a `native-tls` implementation
-+ `fail-on-err` - `panic` on any error
 + `no-verify-ssl` - disable SSL verification for endpoints, useful for custom regions
 
-#### Path or subdomain style URLs and headers
+### Path or subdomain style URLs and headers
 
 `Bucket` struct provides constructors for `path-style` paths, `subdomain` style is the default. `Bucket` exposes methods for configuring and accessing `path-style` configuration.
 
-#### Buckets
+## API
 
-|          |                                                                                         |
-|----------|-----------------------------------------------------------------------------------------|
-| `create` | [async](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.create)      |
-| `delete` | [async](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.delete)      |
-| `list`   | [async](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.list_buckets)|
-| `exists` | [async](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.exists)|
+### Buckets
 
+- `create`
+- `delete`
+- `list`
+- `exists`
+- `location`
 
-#### Presign
+### Objects
 
-|          |                                                                                                     |
-|----------|-----------------------------------------------------------------------------------------------------|
-| `POST`   | [presign_put](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.presign_post)      |
-| `PUT`    | [presign_put](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.presign_put)       |
-| `GET`    | [presign_get](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.presign_get)       |
-| `DELETE` | [presign_delete](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.presign_delete) |
+- `head_object`
+- `get_object`
+- `get_object_stream`
+- `get_object_to_writer`
+- `get_object_tagging`
+- `put_object`
+- `put_object_with_content_type`
+- `put_object_stream`
+- `put_object_tagging`
+- `delete_object`
+- `object_exists`
 
-#### GET
+### Presign
 
-There are a few different options for getting an object and methods are generic over `tokio::io::AsyncWriteExt`.
-
-|                             |                                                                                                                 |
-|-----------------------------|-----------------------------------------------------------------------------------------------------------------|
-| `async/sync/async-blocking` | [get_object](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.get_object)                     |
-| `async/sync/async-blocking` | [get_object_stream](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.get_object_stream)       |
-| `async/sync/async-blocking` | [get_object_to_writer](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.get_object_to_writer) |
-
-#### PUT
-
-Each `GET` method has a `PUT` companion, and `tokio` methods are generic over `tokio::io::AsyncReadExt`.
-
-|                             |                                                                                                                                 |
-|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| `async/sync/async-blocking` | [put_object](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.put_object)                                     |
-| `async/sync/async-blocking` | [put_object_with_content_type](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.put_object_with_content_type) |
-| `async/sync/async-blocking` | [put_object_stream](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.put_object_stream)                       |
-
-#### List
-
-|                             |                                                                                 |
-|-----------------------------|---------------------------------------------------------------------------------|
-| `async/sync/async-blocking` | [list](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.list) |
-
-#### DELETE
-
-|                             |                                                                                                   |
-|-----------------------------|---------------------------------------------------------------------------------------------------|
-| `async/sync/async-blocking` | [delete_object](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.delete_object) |
-
-#### Location
-
-|                             |                                                                                         |
-|-----------------------------|-----------------------------------------------------------------------------------------|
-| `async/sync/async-blocking` | [location](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.location) |
-
-#### Tagging
-
-|                             |                                                                                                             |
-|-----------------------------|-------------------------------------------------------------------------------------------------------------|
-| `async/sync/async-blocking` | [put_object_tagging](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.put_object_tagging) |
-| `async/sync/async-blocking` | [get_object_tagging](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.get_object_tagging) |
-
-#### Head
-
-|                             |                                                                                               |
-|-----------------------------|-----------------------------------------------------------------------------------------------|
-| `async/sync/async-blocking` | [head_object](https://docs.rs/rust-s3-async/latest/s3/bucket/struct.Bucket.html#method.head_object) |
-
-### Usage (in `Cargo.toml`)
-
-```toml
-[dependencies]
-rust-s3-async = "0.34.0"
-```
+- `presign_post`
+- `presign_put`
+- `presign_get`
+- `presign_delete`

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -50,7 +50,6 @@ hyper = { version = "^0.14", default-features = false, features = [
     "stream",
 ] }
 hyper-tls = { version = "0.5.0", default-features = false }
-hyper-native-tls = { version = "0.3.0", default-features = false }
 tracing = { version="0.1.35" }
 md5 = "0.7"
 percent-encoding = "2"
@@ -70,13 +69,11 @@ bytes = { version = "1" }
 strum_macros = "0.24.3"
 
 [features]
-default = ["fail-on-err", "aws-creds/native-tls"]
+default = ["aws-creds/native-tls"]
 no-verify-ssl = []
-fail-on-err = []
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs"] }
-async-std = { version = "1", features = ["attributes"] }
 uuid = { version = "1", features = ["v4"] }
 env_logger = "0.10"
 anyhow = "1"

--- a/s3/src/bucket/get.rs
+++ b/s3/src/bucket/get.rs
@@ -120,8 +120,6 @@ impl Bucket {
     /// let bucket = Bucket::new(bucket_name, region, credentials)?;
     /// let mut output_file = File::create("output_file").expect("Unable to create file");
     /// let mut async_output_file = tokio::fs::File::create("async_output_file").await.expect("Unable to create file");
-    /// #[cfg(feature = "with-async-std")]
-    /// let mut async_output_file = async_std::fs::File::create("async_output_file").await.expect("Unable to create file");
     ///
     /// let start = 0;
     /// let end = Some(1024);
@@ -166,8 +164,6 @@ impl Bucket {
     /// let bucket = Bucket::new(bucket_name, region, credentials)?;
     /// let mut output_file = File::create("output_file").expect("Unable to create file");
     /// let mut async_output_file = tokio::fs::File::create("async_output_file").await.expect("Unable to create file");
-    /// #[cfg(feature = "with-async-std")]
-    /// let mut async_output_file = async_std::fs::File::create("async_output_file").await.expect("Unable to create file");
     ///
     /// let status_code = bucket.get_object_to_writer("/test.file", &mut async_output_file).await?;
     /// #

--- a/s3/src/bucket_tests.rs
+++ b/s3/src/bucket_tests.rs
@@ -171,14 +171,7 @@ mod test {
 
     #[ignore]
     #[cfg(feature = "tags")]
-    #[maybe_async::test(
-        feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
-    )]
+    #[tokio::test]
     async fn test_tagging_aws() {
         let bucket = test_aws_bucket();
         let _target_tags = vec![
@@ -212,14 +205,7 @@ mod test {
 
     #[ignore]
     #[cfg(feature = "tags")]
-    #[maybe_async::test(
-        feature = "sync",
-        async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-        async(
-            all(not(feature = "sync"), feature = "with-async-std"),
-            async_std::test
-        )
-    )]
+    #[tokio::test]
     async fn test_tagging_minio() {
         let bucket = test_minio_bucket();
         let _target_tags = vec![
@@ -392,14 +378,7 @@ mod test {
 
     // Keeps failing on tokio-rustls-tls
     // #[ignore]
-    // #[maybe_async::test(
-    //     feature = "sync",
-    //     async(all(not(feature = "sync"), feature = "with-tokio"), tokio::test),
-    //     async(
-    //         all(not(feature = "sync"), feature = "with-async-std"),
-    //         async_std::test
-    //     )
-    // )]
+    // #[tokio::test]
     // async fn digital_ocean_test_put_head_get_delete_object() {
     //     put_head_get_delete_object(test_digital_ocean_bucket(), true).await;
     // }

--- a/s3/src/request/tokio_backend.rs
+++ b/s3/src/request/tokio_backend.rs
@@ -84,7 +84,7 @@ impl<'a> Request for HyperRequest<'a> {
 
         event!(Level::DEBUG, status_code = response.status().as_u16(),);
 
-        if cfg!(feature = "fail-on-err") && !response.status().is_success() {
+        if !response.status().is_success() {
             let status = response.status().as_u16();
             let text =
                 String::from_utf8(hyper::body::to_bytes(response.into_body()).await?.into())?;

--- a/s3/src/utils.rs
+++ b/s3/src/utils.rs
@@ -187,15 +187,12 @@ mod test {
     #[test]
     fn test_etag_large_file() {
         let path = &TestFile::new(Path::new("test_etag"));
-        std::fs::remove_file(path).unwrap_or(());
         let test: Vec<u8> = object(10_000_000);
 
         let mut file = File::create(path).unwrap();
         file.write_all(&test).unwrap();
 
         let etag = etag_for_path(path).unwrap();
-
-        std::fs::remove_file(path).unwrap_or(());
 
         assert_eq!(etag, "e438487f09f09c042b2de097765e5ac2-2");
     }


### PR DESCRIPTION
- Cleanup `Cargo.toml`
  - Remove unused `async-std` dev-dependency
  - Remove `fail-on-err` feature and make its behavior the default
- Cleanup `README.md`
- Fix flaky tests