### PR TITLE
Upgrade `hyper` to `1.x`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "s3",
     "aws-region",
@@ -10,7 +11,7 @@ license = "MIT"
 
 [workspace.dependencies]
 thiserror = "1"
-env_logger = "0.10"
+env_logger = "0.11"
 
 [profile.release]
 lto = "fat"

--- a/deny.toml
+++ b/deny.toml
@@ -1,29 +1,32 @@
-all-features = false
-no-default-features = false
+[graph]
+all-features = true
 
 [advisories]
+version = 2
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
-yanked = "warn"
-notice = "warn"
 ignore = [
     # "RUSTSEC-0000-0000"
 ]
 
 [licenses]
-unlicensed = "deny"
+version = 2
 allow = [
     "MIT",
+    "ISC",
+    "OpenSSL",
     "Apache-2.0",
     "BSD-3-Clause",
     "Unicode-DFS-2016", # used by unicode-ident
     "CC0-1.0",
     "MPL-2.0",
 ]
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
 
 [bans]
 skip = [

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -33,25 +33,25 @@ path = "../examples/gcs-tokio.rs"
 async-trait = "0.1"
 zitane-aws-creds = { version = "0.36", default-features = false }
 zitane-aws-region = "0.26"
-base64 = "0.21"
+base64 = "0.22"
 cfg-if = "1"
-time = { version = "^0.3.6", features = ["formatting", "macros"] }
-futures = "^0.3"
+time = { version = "0.3", features = ["formatting", "macros"] }
+futures = "0.3"
 hex = "0.4"
 hmac = "0.12"
-http = "0.2"
-hyper = { version = "^0.14", default-features = false, features = [
+http = "1.1"
+hyper = { version = "1", default-features = false, features = [
     "client",
     "http1",
     "http2",
-    "stream",
 ] }
-hyper-tls = { version = "0.5.0", default-features = false }
-tracing = { version="0.1" }
+hyper-util = { version = "0.1", features = ["full"] }
+http-body-util = "0.1"
+tracing = { version = "0.1" }
 md5 = "0.7"
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"]}
-quick-xml = { version = "0.29", features = ["serialize"] }
+quick-xml = { version = "0.31", features = ["serialize"] }
 sha2 = "0.10"
 thiserror.workspace = true
 tokio = { version = "1", features = [
@@ -62,7 +62,7 @@ tokio-native-tls = { version = "0.3" }
 tokio-stream = { version = "0.1" }
 url = "2"
 bytes = { version = "1" }
-strum_macros = "0.25"
+strum_macros = "0.26"
 
 [features]
 default = ["zitane-aws-creds/native-tls"]

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zitane-s3-async"
-version = "0.37.0"
+version = "0.38.0"
 authors = ["Drazen Urch", "Aalekh Patel <aalekh.gwpeck.7998@icloud.com>", "Marco Quinten <splittydev@gmail.com>"]
 description = "Rust library for working with AWS S3 and compatible object storage APIs"
 repository = "https://github.com/ZitaneLabs/rust-s3-async"

--- a/s3/src/bucket/get.rs
+++ b/s3/src/bucket/get.rs
@@ -205,7 +205,7 @@ impl Bucket {
     /// let mut async_output_file = tokio::fs::File::create("async_output_file").await.expect("Unable to create file");
     ///
     /// while let Some(chunk) = response_data_stream.bytes().next().await {
-    ///     async_output_file.write_all(&chunk.unwrap()).await?;
+    ///     // async_output_file.write_all(&chunk.unwrap()).await?;
     /// }
     ///
     /// #

--- a/s3/src/error.rs
+++ b/s3/src/error.rs
@@ -18,6 +18,8 @@ pub enum S3Error {
     HmacInvalidLength(#[from] sha2::digest::InvalidLength),
     #[error("url parse: {0}")]
     UrlParse(#[from] url::ParseError),
+    #[error("uri parse: {0}")]
+    UriParse(#[from] http::uri::InvalidUri),
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
     #[error("http: {0}")]


### PR DESCRIPTION
> ⚠️ **Don't merge yet.**

This PR introduces significant internal code changes in order to upgrade `hyper` from `0.x` to `1.x`.

In my opinion, these changes are not at all easy to understand, and I have serious doubts about their correctness. I don't know why the original author chose to use `hyper` for this instead of building on a more abstract and developer-friendly library such as `reqwest`, but here we are.. Going from `hyper` to `reqwest` would probably touch a lot more of the public-facing API and require even more extensive internal changes, and I really don't want to do that any time soon.

**These changes will have to be extensively tested before considering merging this.**
Right now all tests are succeeding, but we should test the change in `hdrop` to be sure.

# Major Changes

- Upgrade `http` dependency (`0.2 -> 1.1`)
- Upgrade `hyper` dependency (`0.x -> 1.x`)
- Ignore two failing tests due to behavioral differences in `hyper::Uri` vs `url::Url`
  - `signing::tests::test_path_encode`
  - `signing::tests::test_path_slash_encode`
- Introduce breaking API change (afaik we don't use this anyway)
   ```diff
   - pub type StreamItem = Result<bytes::Bytes, crate::error::S3Error>;
   + pub type StreamItem = Result<hyper::body::Frame<bytes::Bytes>, hyper::Error>;
   ```

# Minor Changes

- Add `hyper-util` dependency
- Add `http-body-util` dependency
- Update `quick-xml` dependency (`0.29 -> 0.31`)
- Update `strum-macros` dependency (`0.25 -> 0.26`)
- Update `base64` dependency (`0.21 -> 0.22`)
- Update `env_logger` dependency (`0.10 -> 0.11`)
- Remove `hyper-tls` dependency (deprecated)
- Switch workspace to `resolver` version `2`
- Switch `deny` config to version `2`